### PR TITLE
chore: add release auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -1,0 +1,38 @@
+name: Auto Tag Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from package.json
+        id: version
+        run: |
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        env:
+          TAG_NAME: v${{ steps.version.outputs.version }}
+          TARGET_COMMITISH: ${{ github.event.release.target_commitish }}
+        run: |
+          git fetch --all --tags
+          if git rev-parse "refs/tags/$TAG_NAME" >/dev/null 2>&1; then
+            echo "Tag $TAG_NAME already exists."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG_NAME" "$TARGET_COMMITISH"
+          git push origin "$TAG_NAME"


### PR DESCRIPTION
### Motivation
- Add an automated GitHub Actions workflow to generate a git tag from the repository `package.json` version when a release is published.

### Description
- Add `.github/workflows/auto-tag-release.yml` which triggers on `release: published`, reads the `version` from `package.json`, and creates/pushes a `v<version>` tag pointing at `github.event.release.target_commitish` if the tag does not already exist.

### Testing
- Pre-commit hooks (`eslint` and `commitlint`) ran during the commit process; the first commit attempt failed due to a `commitlint` message error and the subsequent commit passed, and the workflow file was added; the workflow itself was not executed in CI here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69830686d7f4832ca67214e80748b0a5)